### PR TITLE
redirect stderr/stdout of process to files inside boba_logs/ folder

### DIFF
--- a/boba/bobarun.py
+++ b/boba/bobarun.py
@@ -1,9 +1,8 @@
 import subprocess
 import os
 from .lang import Lang
-from .wrangler import DIR_SCRIPT
+from .wrangler import DIR_SCRIPT, DIR_LOG, get_universe_id_from_script, get_universe_log
 from subprocess import PIPE
-
 
 def run_batch_of_universes(folder, universes):
     """ Run a batch of universes """
@@ -21,8 +20,19 @@ def run_universe(folder, script):
                            stdout=PIPE, stderr=PIPE)
     # it's ok to block here because this function will be running as a separate process
     output, err = out.communicate()
-    print(err.decode('utf-8'), end='')
-    print(script + '\n' + output.decode('utf-8'), end='')
+    out_decoded = output.decode('utf-8')
+    err_decoded = err.decode('utf-8')
+    universe_id = get_universe_id_from_script(script)
+    log_dir = os.path.join(folder, DIR_LOG)
+    
+    with open(os.path.join(log_dir, get_universe_log(universe_id)), 'w') as log:
+        log.write("stdout:\n")
+        log.write(out_decoded)
+        log.write("stderr:\n")
+        log.write(err_decoded)
+
+    print(script + '\n' + out_decoded, end='')
+    print(err_decoded, end='')
     return script.split('.')[0], out.returncode
 
 

--- a/boba/wrangler.py
+++ b/boba/wrangler.py
@@ -78,6 +78,16 @@ def get_universe_script(universe_id, lang_extension):
     return 'universe_' + str(universe_id) + lang_extension
 
 
+def get_universe_id_from_script(universe_script):
+    """ Get the id of a universe given the universe script """
+    return int(universe_script.split('.')[0].split('_')[1])
+
+
+def get_universe_log(universe_id):
+    """ Get the file name of a universe log """
+    return "log_" + str(universe_id) + ".txt"
+
+
 class Wrangler:
     """Handles outputs."""
     def __init__(self, spec, lang, out):


### PR DESCRIPTION
fixes #11. Redirects all `stderr` and `stdout` to appropriate file inside `boba_logs/` folder (`log_<x>.txt` for `universe_<x>.<py/R>`)