### PR TITLE
boba compile now works on python 3.8.2

### DIFF
--- a/boba/adg.py
+++ b/boba/adg.py
@@ -84,7 +84,7 @@ class ADG:
             gp = self._merge_one(nd, set(cur))
 
             # if the child node is already in groups, give it a different id
-            for g in gp:
+            for g in gp.copy():
                 val = gp[g]
                 key = '{}-{}'.format(g, i) if g in groups else g
                 i += 1 if g in groups else 0


### PR DESCRIPTION
fixes #8 
the issue was here:
```
    -->   for g in gp:
                val = gp[g]
                key = '{}-{}'.format(g, i) if g in groups else g
                i += 1 if g in groups else 0
    --->        del gp[g]
                gp[key] = val
```
in python 3.8.2, changing a dictionary while iterating over it's keys is illegal. To fix this, simply change `for g in gp` to `for g in gp.copy()`