### PR TITLE
fixes-#17

### DIFF
--- a/boba/bobarun.py
+++ b/boba/bobarun.py
@@ -1,7 +1,7 @@
 import subprocess
 import os
 from .lang import Lang
-from .wrangler import DIR_SCRIPT, DIR_LOG, get_universe_id_from_script, get_universe_log
+from .wrangler import DIR_SCRIPT, DIR_LOG, get_universe_id_from_script, get_universe_log, get_universe_error_log, get_universe_name
 from subprocess import PIPE
 
 def run_batch_of_universes(folder, universes):
@@ -18,22 +18,30 @@ def run_universe(folder, script):
     cmd = Lang('', script).get_cmd()
     out = subprocess.Popen([cmd, script], cwd=os.path.join(folder, DIR_SCRIPT),
                            stdout=PIPE, stderr=PIPE)
-    # it's ok to block here because this function will be running as a separate process
-    output, err = out.communicate()
-    out_decoded = output.decode('utf-8')
-    err_decoded = err.decode('utf-8')
-    universe_id = get_universe_id_from_script(script)
-    log_dir = os.path.join(folder, DIR_LOG)
-    
-    with open(os.path.join(log_dir, get_universe_log(universe_id)), 'w') as log:
-        log.write("stdout:\n")
-        log.write(out_decoded)
-        log.write("stderr:\n")
-        log.write(err_decoded)
 
-    print(script + '\n' + out_decoded, end='')
-    print(err_decoded, end='')
-    return script.split('.')[0], out.returncode
+    universe_id = get_universe_id_from_script(script)
+    universe_name_fmt = "[" + get_universe_name(universe_id) + "]"
+    log_dir = os.path.join(folder, DIR_LOG)
+    with open(os.path.join(log_dir, get_universe_log(universe_id)), 'w') as log:
+        while True:
+            # blocks here until next line is availible.
+            output = out.stdout.readline().decode('utf-8')
+            if output == '' and out.poll() is not None:
+                break
+            if output:
+                print(universe_name_fmt + " " + output, end='')
+                log.write(output)
+            rc = out.poll()
+
+    err = out.communicate()[1]
+    err_decoded = err.decode('utf-8')
+    if err_decoded is not "":
+        with open(os.path.join(log_dir, get_universe_error_log(universe_id)), 'w') as err_log:
+            err_log.write(err_decoded)
+        
+        print(universe_name_fmt + " error:\n" + err_decoded, end='')
+
+    return get_universe_name(universe_id), out.returncode
 
 
 def run_commands_in_folder(folder, file_with_commands):

--- a/boba/cli.py
+++ b/boba/cli.py
@@ -2,6 +2,7 @@
 
 """Console script."""
 import click
+import shutil
 from .parser import Parser
 from .output.csvmerger import CSVMerger
 import multiprocessing as mp
@@ -106,8 +107,9 @@ def run(folder, run_all, num, thru, jobs, batch_size):
     results = []
 
     p_log = os.path.join(folder, DIR_LOG)
-    if not os.path.exists(p_log):
-        os.makedirs(p_log)
+    if os.path.exists(p_log):
+        shutil.rmtree(p_log)
+    os.makedirs(p_log)
 
     with open(os.path.join(p_log, 'logs.csv'), 'w') as log:
         log.write('universe,exit_code\n')

--- a/boba/wrangler.py
+++ b/boba/wrangler.py
@@ -71,11 +71,16 @@ merge_log
 
 DIR_SCRIPT = 'code/'
 DIR_LOG = 'boba_logs/'
+LOG_EXT = '.txt'
+
+def get_universe_name(universe_id):
+    """ Get the name of a universe """
+    return 'universe_' + str(universe_id)
 
 
 def get_universe_script(universe_id, lang_extension):
     """ Get the file name of a universe script """
-    return 'universe_' + str(universe_id) + lang_extension
+    return get_universe_name(universe_id) + lang_extension
 
 
 def get_universe_id_from_script(universe_script):
@@ -85,7 +90,12 @@ def get_universe_id_from_script(universe_script):
 
 def get_universe_log(universe_id):
     """ Get the file name of a universe log """
-    return "log_" + str(universe_id) + ".txt"
+    return 'log_' + str(universe_id) + LOG_EXT
+
+
+def get_universe_error_log(universe_id):
+    """ get the file name of a universe error log """
+    return 'error_' + str(universe_id) + LOG_EXT
 
 
 class Wrangler:


### PR DESCRIPTION
fixes #17. This makes it so that the `stdout` of a process is printed and logged immediately instead of at the end of the process. `stderr` is still printed at the end of the process because if a program is printing to `stderr`, it has encountered an error and stopped, so printing `stderr` at the end of a process is equivalent to printing it "in real time".

Also, note that boba_logs/ contains two types of files now, `log_x.txt` and `error_x.txt`. `log_x.txt` files contain stdout info, and `error_x.txt` files contain stderr info. `error_x.txt` files are only generated for processes that printed something to stderr. Before each run, the boba_logs/ folder is deleted and re-created to remove old error logs.